### PR TITLE
Changed react-native-gesture-handler version to fix an android build bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-navigation/stack": "^6.3.21",
     "@types/jest": "^29.5.12",
     "@types/react-test-renderer": "^18.0.7",
-    "expo": "~50.0.6",
+    "expo": "^50.0.6",
     "expo-status-bar": "~1.11.1",
     "jest": "^29.7.0",
     "jest-expo": "^50.0.2",
@@ -29,7 +29,7 @@
     "npm": "^10.4.0",
     "react": "18.2.0",
     "react-native": "0.73.4",
-    "react-native-gesture-handler": "^2.15.0",
+    "react-native-gesture-handler": "~2.14.0",
     "react-native-safe-area-context": "^4.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes an issue where it wasn't building on android. 

Tested build both on iOS and Android.

